### PR TITLE
Transfer interpolated solution values back to dest mesh

### DIFF
--- a/src/Main/Transporter.cpp
+++ b/src/Main/Transporter.cpp
@@ -206,8 +206,8 @@ Transporter::workcreated( std::size_t meshid )
   m_sourcemeshid = 0;
   m_destmeshid = 1;
   if (completed == meshes.size()) {
-    meshes[m_sourcemeshid].m_worker.collideVertices();
-    meshes[m_destmeshid].m_worker.collideTets();
+    meshes[m_sourcemeshid].m_worker.collideTets();
+    meshes[m_destmeshid].m_worker.collideVertices();
   }
 }
 
@@ -247,8 +247,8 @@ Transporter::processCollisions(int nColl, Collision* colls)
 // *****************************************************************************
 {
   std::cout << "Collisions found: " << nColl << std::endl;
-  std::size_t first = meshes[m_sourcemeshid].m_firstchunk;
-  std::size_t nchare = meshes[m_sourcemeshid].m_nchare;
+  std::size_t first = meshes[m_destmeshid].m_firstchunk;
+  std::size_t nchare = meshes[m_destmeshid].m_nchare;
   std::vector<Collision>* separated = new std::vector<Collision>[nchare];
   for (int i = 0; i < nColl; i++) {
     if (colls[i].A.chunk >= first && colls[i].A.chunk < first + nchare) {
@@ -259,8 +259,8 @@ Transporter::processCollisions(int nColl, Collision* colls)
   }
 
   for (int i = 0; i < nchare; i++) {
-    CkPrintf("Source mesh chunk %i has %i\n", i, separated[i].size());
-    meshes[m_sourcemeshid].m_worker[i].processCollisions(separated[i].size(), separated[i].data(), meshes[m_destmeshid].m_nchare, meshes[m_destmeshid].m_firstchunk, meshes[m_destmeshid].m_worker);
+    CkPrintf("Dest mesh chunk %i has %i\n", i, separated[i].size());
+    meshes[m_destmeshid].m_worker[i].processCollisions(separated[i].size(), separated[i].data(), meshes[m_sourcemeshid].m_nchare, meshes[m_sourcemeshid].m_firstchunk, meshes[m_sourcemeshid].m_worker);
   }
 
   delete[] separated;

--- a/src/Transfer/Worker.hpp
+++ b/src/Transfer/Worker.hpp
@@ -82,7 +82,10 @@ class Worker : public CBase_Worker {
                             CProxy_Worker proxy );
 
     //! Identify actual collisions by calling intet function on all possible collisions
-    void determineActualCollisions( int nPoints, std::pair<CkVector3d, int>* points );
+    void determineActualCollisions( CProxy_Worker proxy, int index, int nPoints, std::pair<CkVector3d, int>* points );
+
+    //! Transfer the interpolated solution data back to the points in the dest mesh
+    void transferSolution( int nPoints, std::pair<int, tk::real>* soln );
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{
@@ -181,7 +184,7 @@ class Worker : public CBase_Worker {
     //! Determine if a point is in a tet
     bool intet(const CkVector3d &point,
                std::size_t e,
-               std::array< real, 4 >& N);
+               std::array< real, 4 >& N) const;
 };
 
 } // exam2m::

--- a/src/Transfer/worker.ci
+++ b/src/Transfer/worker.ci
@@ -41,8 +41,12 @@ module worker {
                                     std::size_t nchares,
                                     std::size_t offset,
                                     CProxy_Worker proxy );
-      entry void determineActualCollisions( int nPoints,
+      entry void determineActualCollisions( CProxy_Worker proxy,
+                                            int index,
+                                            int nPoints,
                                             std::pair<CkVector3d,int> points[nPoints] );
+      entry void transferSolution( int nPoints,
+                                   std::pair<int, tk::real> soln[nPoints] );
     }
 
   } // exam2m::


### PR DESCRIPTION
Previously we had switched the source and dest mesh in doing collision
detection. Here we change it so the vertices of dest are collided against the
tets of the source mesh. Beyond that, once actual collisions are determined,
the source mesh determines the solution value at the dest vertices and sends
that information back to the destination mesh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/charmworks/exam2m/11)
<!-- Reviewable:end -->
