### PR TITLE
Transfer control flow to SDAG

### DIFF
--- a/src/Main/ExaM2M.cpp
+++ b/src/Main/ExaM2M.cpp
@@ -82,7 +82,7 @@ class Main : public CBase_Main {
       delete msg;
       mainProxy = thisProxy;
       transporterProxy = CProxy_Transporter::ckNew( 0 );
-      CkStartQD( CkCallback( CkIndex_Main::quiescence(), thisProxy ) );
+      transporterProxy.run();
       // Fire up an asynchronous execute object, which when created at some
       // future point in time will call back to this->execute(). This is
       // necessary so that this->execute() can access already migrated

--- a/src/Main/Mapper.cpp
+++ b/src/Main/Mapper.cpp
@@ -17,8 +17,7 @@
 
 using exam2m::Mapper;
 
-Mapper::Mapper( std::size_t meshid,
-                const tk::CProxy_MeshWriter& meshwriter,
+Mapper::Mapper( const tk::CProxy_MeshWriter& meshwriter,
                 const CProxy_Worker& worker,
                 const tk::MapperCallback& cbm,
                 const tk::WorkerCallback& cbw,
@@ -28,7 +27,6 @@ Mapper::Mapper( std::size_t meshid,
                 const std::vector< std::size_t >& triinpoel,
                 const std::map< int, std::vector< std::size_t > >& bnode,
                 int nchare ) :
-  m_meshid (meshid),
   m_meshwriter( meshwriter ),
   m_worker( worker ),
   m_cbm( cbm ),
@@ -119,8 +117,7 @@ Mapper::setup( std::size_t npoin, std::size_t firstchunk )
   // on the sender side, i.e., this chare.
   m_nbnd = chbnd.size();
   if (m_nbnd == 0)
-    contribute( sizeof(std::size_t), &m_meshid, CkReduction::nop,
-        m_cbm.get< tag::queried >() );
+    contribute( m_cbm.get< tag::queried >() );
   else
     for (const auto& [ targetchare, bnd ] : chbnd)
       thisProxy[ targetchare ].query( thisIndex, bnd );
@@ -156,8 +153,7 @@ Mapper::recvquery()
 // *****************************************************************************
 {
   if (--m_nbnd == 0)
-    contribute( sizeof(std::size_t), &m_meshid, CkReduction::nop,
-        m_cbm.get< tag::queried >() );
+    contribute( m_cbm.get< tag::queried >() );
 }
 
 void
@@ -195,8 +191,7 @@ Mapper::response()
   // the responses on the sender side, i.e., this chare.
   m_nbnd = exp.size();
   if (m_nbnd == 0)
-    contribute( sizeof(std::size_t), &m_meshid, CkReduction::nop,
-        m_cbm.get< tag::responded >() );
+    contribute( m_cbm.get< tag::responded >() );
   else
     for (const auto& [ targetchare, maps ] : exp)
       thisProxy[ targetchare ].bnd( thisIndex, maps );
@@ -229,8 +224,7 @@ Mapper::recvbnd()
 // *****************************************************************************
 {
   if (--m_nbnd == 0)
-    contribute( sizeof(std::size_t), &m_meshid, CkReduction::nop,
-        m_cbm.get< tag::responded >() );
+    contribute( m_cbm.get< tag::responded >() );
 }
 
 void
@@ -239,11 +233,10 @@ Mapper::create()
 //  Create worker chare array elements
 // *****************************************************************************
 {
-  m_worker[ thisIndex ].insert( m_meshid, m_firstchunk, m_meshwriter, m_cbw,
+  m_worker[ thisIndex ].insert( m_firstchunk, m_meshwriter, m_cbw,
     m_ginpoel, m_coordmap, m_commap, m_bface, m_triinpoel, m_bnode, m_nchare );
 
-    contribute( sizeof(std::size_t), &m_meshid, CkReduction::nop,
-        m_cbm.get< tag::workinserted >() );
+    contribute( m_cbm.get< tag::workinserted >() );
 
   // Free up some memory
   tk::destroy( m_ginpoel );

--- a/src/Main/Mapper.hpp
+++ b/src/Main/Mapper.hpp
@@ -30,8 +30,7 @@ class Mapper : public CBase_Mapper {
 
   public:
     //! Constructor
-    explicit Mapper( std::size_t meshid,
-                     const tk::CProxy_MeshWriter& meshwriter,
+    explicit Mapper( const tk::CProxy_MeshWriter& meshwriter,
                      const CProxy_Worker& worker,
                      const tk::MapperCallback& cbm,
                      const tk::WorkerCallback& cbw,
@@ -98,8 +97,6 @@ class Mapper : public CBase_Mapper {
     //@}
 
   private:
-    //! Mesh ID
-    std::size_t m_meshid;
     //! First chunk ID for collision detection
     std::size_t m_firstchunk;
     //! MeshWriter proxy

--- a/src/Main/Partitioner.cpp
+++ b/src/Main/Partitioner.cpp
@@ -21,7 +21,6 @@
 using exam2m::Partitioner;
 
 Partitioner::Partitioner(
-  int meshid,
   const std::string& meshfilename,
   const tk::PartitionerCallback& cbp,
   const tk::MapperCallback& cbm,
@@ -32,7 +31,6 @@ Partitioner::Partitioner(
   const std::map< int, std::vector< std::size_t > >& bface,
   const std::map< int, std::vector< std::size_t > >& faces,
   const std::map< int, std::vector< std::size_t > >& bnode ) :
-  m_meshid( meshid ),
   m_cbp( cbp ),
   m_cbm( cbm ),
   m_cbw( cbw ),
@@ -83,9 +81,8 @@ Partitioner::Partitioner(
   ownBndNodes( m_lid, m_bnode );
 
   // Compute number of cells across whole problem
-  std::size_t data[] = { 0, m_ginpoel.size() / 4 };
-  if (thisIndex == 0) data[0] = m_meshid;
-  contribute( 2 * sizeof(std::size_t), data, CkReduction::sum_ulong,
+  std::size_t data = m_ginpoel.size() / 4;
+  contribute( sizeof(std::size_t), &data, CkReduction::sum_ulong,
               m_cbp.get< tag::load >() );
 }
 
@@ -231,8 +228,7 @@ Partitioner::recvMesh()
 // *****************************************************************************
 {
   if (--m_ndist == 0)
-    contribute( sizeof(std::size_t), &m_meshid, CkReduction::nop,
-        m_cbp.get< tag::distributed >() );
+    contribute( m_cbp.get< tag::distributed >() );
 }
 
 std::array< std::vector< tk::real >, 3 >
@@ -465,8 +461,7 @@ Partitioner::distribute( std::unordered_map< int, MeshData >&& mesh )
 
   // Export chare IDs and mesh we do not own to fellow compute nodes
   if (exp.empty()) {
-    contribute( sizeof(std::size_t), &m_meshid, CkReduction::nop,
-        m_cbp.get< tag::distributed >() );
+    contribute( m_cbp.get< tag::distributed >() );
   } else {
      m_ndist += exp.size();
      for (const auto& [ targetchare, chunk ] : exp)
@@ -515,8 +510,7 @@ Partitioner::map()
       // compute chare ID
       auto cid = CkMyNode() * dist[0] + c;
       // create Mapper Charm++ chare array elements
-      m_mapper[ cid ].insert( m_meshid,
-                              m_meshwriter,
+      m_mapper[ cid ].insert( m_meshwriter,
                               m_worker,
                               m_cbm,
                               m_cbw,
@@ -547,9 +541,7 @@ Partitioner::map()
   tk::destroy( m_triinpoel );
   tk::destroy( m_bnode );
 
-  std::size_t data[] = { 0, error };
-  if (thisIndex == 0) data[0] = m_meshid;
-  contribute( 2 * sizeof(std::size_t), &data, CkReduction::max_ulong,
+  contribute( sizeof(std::size_t), &error, CkReduction::max_ulong,
               m_cbp.get< tag::mapinserted >() );
 }
 

--- a/src/Main/Partitioner.hpp
+++ b/src/Main/Partitioner.hpp
@@ -38,8 +38,7 @@ class Partitioner : public CBase_Partitioner {
 
   public:
     //! Constructor
-    Partitioner( int meshid,
-                 const std::string& meshfilename,
+    Partitioner( const std::string& meshfilename,
                  const tk::PartitionerCallback& cbp,
                  const tk::MapperCallback& cbm,
                  const tk::WorkerCallback& cbw,
@@ -86,7 +85,6 @@ class Partitioner : public CBase_Partitioner {
     //! \note This is a Charm++ nodegroup, pup() is thus only for
     //!    checkpoint/restart.
     void pup( PUP::er &p ) override {
-      p | m_meshid;
       p | m_cbp;
       p | m_meshwriter;
       p | m_ginpoel;
@@ -115,8 +113,6 @@ class Partitioner : public CBase_Partitioner {
     //@}
 
   private:
-    //! The ID of the mesh, supplied by the Transporter
-    int m_meshid;
     //! Charm++ callbacks associated to compile-time tags for Partitioner
     tk::PartitionerCallback m_cbp;
     //! Charm++ callbacks associated to compile-time tags for Mapper

--- a/src/Main/Transporter.cpp
+++ b/src/Main/Transporter.cpp
@@ -24,13 +24,13 @@ extern CProxy_Main mainProxy;
 
 using exam2m::Transporter;
 
-Transporter::Transporter() : completed(0), m_currentchunk(0)
+Transporter::Transporter() : m_currentchunk(0)
 // *****************************************************************************
 //  Constructor
 // *****************************************************************************
 {}
 
-void Transporter::addMesh( const std::string& file )
+void Transporter::initMeshData( const std::string& file )
 // *****************************************************************************
 //  addMesh
 //! \param[in] file Name of the file to read the mesh data from
@@ -56,10 +56,13 @@ void Transporter::addMesh( const std::string& file )
 
   // Create Partitioner callbacks (order matters)
   tk::PartitionerCallback cbp {{
-      CkCallback( CkReductionTarget(Transporter,load), thisProxy )
+      CkCallback( CkReductionTarget(Transporter,loaded), thisProxy )
     , CkCallback( CkReductionTarget(Transporter,distributed), thisProxy )
     , CkCallback( CkReductionTarget(Transporter,mapinserted), thisProxy )
   }};
+  cbp.get<tag::load>().setRefnum(meshid);
+  cbp.get<tag::distributed>().setRefnum(meshid);
+  cbp.get<tag::mapinserted>().setRefnum(meshid);
 
   // Create Mapper callbacks (order matters)
   tk::MapperCallback cbm {{
@@ -67,12 +70,17 @@ void Transporter::addMesh( const std::string& file )
     , CkCallback( CkReductionTarget(Transporter,responded), thisProxy )
     , CkCallback( CkReductionTarget(Transporter,workinserted), thisProxy )
   }};
+  cbm.get<tag::queried>().setRefnum(meshid);
+  cbm.get<tag::responded>().setRefnum(meshid);
+  cbm.get<tag::workinserted>().setRefnum(meshid);
 
   // Create Worker callbacks (order matters)
   tk::WorkerCallback cbw {{
       CkCallback( CkReductionTarget(Transporter,workcreated), thisProxy )
     , CkCallback( CkReductionTarget(Transporter,written), thisProxy )
   }};
+  cbw.get<tag::workcreated>().setRefnum(meshid);
+  cbw.get<tag::written>().setRefnum(meshid);
 
   // Create MeshWriter chare group
   mesh.m_meshwriter = tk::CProxy_MeshWriter::ckNew();
@@ -85,14 +93,14 @@ void Transporter::addMesh( const std::string& file )
 
   // Create Partitioner nodegroup
   mesh.m_partitioner =
-    CProxy_Partitioner::ckNew( meshid, file, cbp, cbm, cbw,
+    CProxy_Partitioner::ckNew( file, cbp, cbm, cbw,
        mesh.m_meshwriter, mesh.m_mapper, mesh.m_worker, bface, faces, bnode );
 
   meshes.push_back(mesh);
 }
 
 void
-Transporter::load( std::size_t meshid, std::size_t nelem )
+Transporter::updatenelems( std::size_t meshid, std::size_t nelem )
 // *****************************************************************************
 // Reduction target: the mesh has been read from file on all PEs
 //! \param[in] nelem Total number of mesh elements (summed across all nodes)
@@ -103,7 +111,6 @@ Transporter::load( std::size_t meshid, std::size_t nelem )
 
   // Compute load distribution given total work (nelem) and virtualization
   uint64_t chunksize, remainder;
-  // TODO: This needs to be used to ensure unique chunk IDs at some point?
   meshes[meshid].m_nchare = static_cast< int >(
                tk::linearLoadDistributor( virtualization,
                  nelem, CkNumPes(), chunksize, remainder ) );
@@ -111,114 +118,12 @@ Transporter::load( std::size_t meshid, std::size_t nelem )
   m_currentchunk += meshes[meshid].m_nchare;
 
   // Print out info on load distribution
-  std::cout << "Initial load distribution\n";
+  std::cout << "Initial load distribution for mesh " << meshid << "\n";
   std::cout << "Virtualization [0.0...1.0]: " << virtualization << '\n';
   std::cout << "Number of work units: " << meshes[meshid].m_nchare << '\n';
 
   // Tell the meshwriter the total number of chares
   meshes[meshid].m_meshwriter.nchare( meshes[meshid].m_nchare );
-
-  // Partition the mesh
-  meshes[meshid].m_partitioner.partition( meshes[meshid].m_nchare );
-}
-
-void
-Transporter::distributed( std::size_t meshid )
-// *****************************************************************************
-// Reduction target: all PEs have distrbuted their mesh after partitioning
-// *****************************************************************************
-{
-  meshes[meshid].m_partitioner.map();
-}
-
-void
-Transporter::mapinserted( std::size_t meshid, std::size_t error )
-// *****************************************************************************
-// Reduction target: all PEs have created their Mappers
-//! \param[in] error aggregated across all PEs with operator max
-// *****************************************************************************
-{
-  if (error) {
-
-    std::cout << "\n>>> ERROR: A Mapper chare was not assigned any mesh "
-              "elements. This can happen in SMP-mode with a large +ppn "
-              "parameter (number of worker threads per logical node) and is "
-              "most likely the fault of the mesh partitioning algorithm not "
-              "tolerating the case when it is asked to divide the "
-              "computational domain into a number of partitions different "
-              "than the number of ranks it is called on, i.e., in case of "
-              "overdecomposition and/or calling the partitioner in SMP mode "
-              "with +ppn larger than 1. Solution 1: Try a different "
-              "partitioning algorithm (e.g., rcb instead of mj). Solution 2: "
-              "Decrease +ppn.";
-
-    finish();
-
-  } else {
-
-     meshes[meshid].m_mapper.doneInserting();
-     meshes[meshid].m_mapper.setup( meshes[meshid].m_npoin, meshes[meshid].m_firstchunk );
-
-  }
-}
-
-void
-Transporter::queried( std::size_t meshid )
-// *****************************************************************************
-// Reduction target: all Mapper chares have queried their boundary nodes
-// *****************************************************************************
-{
-  meshes[meshid].m_mapper.response();
-}
-
-void
-Transporter::responded( std::size_t meshid )
-// *****************************************************************************
-// Reduction target: all Mapper chares have responded with their boundary nodes
-// *****************************************************************************
-{
-  meshes[meshid].m_mapper.create();
-}
-
-void
-Transporter::workinserted( std::size_t meshid )
-// *****************************************************************************
-// Reduction target: all Workers have been created
-// *****************************************************************************
-{
-  meshes[meshid].m_worker.doneInserting();
-} 
-
-void
-Transporter::workcreated( std::size_t meshid )
-// *****************************************************************************
-// Reduction target: all Worker constructors have been called
-// *****************************************************************************
-{
-  std::cout << "Number of tetrahedra for mesh " << meshid << ": "
-      << meshes[meshid].m_nelem << '\n';;
-  std::cout << "Number of points for mesh " << meshid << ": "
-      << meshes[meshid].m_npoin << '\n';
-
-  meshes[meshid].m_worker.out();
-
-  completed++;
-  m_sourcemeshid = 0;
-  m_destmeshid = 1;
-  if (completed == meshes.size()) {
-    meshes[m_sourcemeshid].m_worker.collideTets();
-    meshes[m_destmeshid].m_worker.collideVertices();
-  }
-}
-
-void
-Transporter::written()
-// *****************************************************************************
-// Reduction target: all Workers have written out mesh/field data
-// *****************************************************************************
-{
-  // FIXME: No guarantee the write finishes.
-  //finish();
 }
 
 Transporter::Transporter( CkMigrateMessage* m ) : CBase_Transporter( m )
@@ -231,17 +136,7 @@ Transporter::Transporter( CkMigrateMessage* m ) : CBase_Transporter( m )
 }
 
 void
-Transporter::finish()
-// *****************************************************************************
-// Normal finish of time stepping
-// *****************************************************************************
-{
-  std::cout << "Normal finish\n";
-  mainProxy.finalize();
-}
-
-void
-Transporter::processCollisions(int nColl, Collision* colls)
+Transporter::distributeCollisions(int nColl, Collision* colls)
 // *****************************************************************************
 // Normal finish of time stepping
 // *****************************************************************************

--- a/src/Main/Transporter.hpp
+++ b/src/Main/Transporter.hpp
@@ -22,42 +22,13 @@ namespace exam2m{
 
 //! Transporter drives time integration
 class Transporter : public CBase_Transporter {
-
+Transporter_SDAG_CODE;
   public:
     //! Constructor
     explicit Transporter();
 
     //! Migrate constructor: returning from a checkpoint
     explicit Transporter( CkMigrateMessage* m );
-
-    //! Add mesh by filename
-    void addMesh( const std::string& file );
-
-    //! Reduction target: the mesh has been read from file on all PEs
-    void load( std::size_t meshid, std::size_t nelem );
-
-    //! Reduction target: all PEs have distrbuted their mesh after partitioning
-    void distributed( std::size_t meshid );
-
-    //! Reduction target: all PEs have created their Mappers
-    void mapinserted( std::size_t meshid, std::size_t error );
-
-    //! Reduction target: all Mapper chares have queried their boundary nodes
-    void queried( std::size_t meshid );
-    //! \brief Reduction target: all Mapper chares have responded with their
-    //!   boundary nodes
-    void responded( std::size_t meshid );
-
-    ///! Reduction target: all Workers have been created
-    void workinserted( std::size_t meshid );
-
-    //! Reduction target: all Worker constructors have been called
-    void workcreated( std::size_t meshid );
-
-    //! Reduction target: all Workers have written out mesh/field data
-    void written();
-
-    void processCollisions( int nColl, Collision* colls );
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{
@@ -78,6 +49,17 @@ class Transporter : public CBase_Transporter {
 
   private:
 
+    //! Add mesh by filename
+    void initMeshData( const std::string& file );
+
+    //! Once partitioner returns initial partitioning info, update the
+    //! number of elements and number of chares in the associated mesh
+    void updatenelems( std::size_t meshid, std::size_t nelems );
+
+    //! Take collision list and distribute it to the destination mesh
+    //! to start testing for actual collisions
+    void distributeCollisions( int nColl, Collision* colls );
+
     struct MeshData {
       int m_nchare;                        //!< Number of worker chares
       int m_firstchunk;                    //!< First chunk ID (for collision)
@@ -88,14 +70,16 @@ class Transporter : public CBase_Transporter {
       std::size_t m_nelem;                 //!< Total number of elements in mesh
       std::size_t m_npoin;                 //!< Total number of nodes in mesh
     };
+    //! Mesh Data for all meshes
     std::vector<MeshData> meshes;
+    //! Chunk counter for ensuring unique chunk number for each mesh
     std::size_t m_currentchunk;
+    //! ID of the source mesh
     std::size_t m_sourcemeshid;
+    //! ID of the dest mesh
     std::size_t m_destmeshid;
-    int completed;
-
-    //! Normal finish of time stepping
-    void finish();
+    //! SDAG variable for mesh ID, used as a refnum in iteration
+    std::size_t m_meshid;
 };
 
 } // exam2m::

--- a/src/Main/mapper.ci
+++ b/src/Main/mapper.ci
@@ -19,8 +19,7 @@ module mapper {
   namespace exam2m {
 
     array [1D] Mapper {
-      entry Mapper( std::size_t meshid,
-                    const tk::CProxy_MeshWriter& meshwriter,
+      entry Mapper( const tk::CProxy_MeshWriter& meshwriter,
                     const CProxy_Worker& worker,
                     const tk::MapperCallback& cbm,
                     const tk::WorkerCallback& cbw,

--- a/src/Main/partitioner.ci
+++ b/src/Main/partitioner.ci
@@ -23,7 +23,6 @@ module partitioner {
 
     nodegroup [migratable] Partitioner {
       entry Partitioner(
-        int mesh_id,
         const std::string& meshfilename,
         const tk::PartitionerCallback& cbp,
         const tk::MapperCallback& cbm,

--- a/src/Main/transporter.ci
+++ b/src/Main/transporter.ci
@@ -18,16 +18,95 @@ module transporter {
 
     chare [migratable] Transporter {
       entry Transporter();
-      entry void addMesh( const std::string& mesh );
-      entry [reductiontarget] void load( std::size_t meshid, std::size_t nelem );
-      entry [reductiontarget] void distributed( std::size_t meshid );
-      entry [reductiontarget] void mapinserted( std::size_t meshid, std::size_t error );
-      entry [reductiontarget] void queried( std::size_t meshid );
-      entry [reductiontarget] void responded( std::size_t meshid );
-      entry [reductiontarget] void workinserted( std::size_t meshid );
-      entry [reductiontarget] void workcreated( std::size_t meshid );
+      entry void addMesh( const std::string& meshfile );
+      entry [reductiontarget] void loaded( std::size_t nelem );
+      entry [reductiontarget] void distributed();
+      entry [reductiontarget] void mapinserted( std::size_t error );
+      entry [reductiontarget] void queried();
+      entry [reductiontarget] void responded();
+      entry [reductiontarget] void workinserted();
+      entry [reductiontarget] void workcreated();
       entry [reductiontarget] void written();
       entry void processCollisions( int nColls, Collision colls[nColls] );
+      entry void solutionFound();
+
+      entry void run() {
+        forall [m_meshid] (0:1,1) {
+          when addMesh( const std::string& meshfile ) {
+            // Create initial MeshData struct, and begin mesh loading
+            serial { initMeshData( meshfile ); }
+
+            // Once loaded, update number of elements and partition
+            when loaded[m_meshid]( std::size_t nelem ) serial {
+              updatenelems(m_meshid, nelem);
+
+              meshes[m_meshid].m_partitioner.partition( meshes[m_meshid].m_nchare );
+            }
+            when distributed[m_meshid]() serial {
+              meshes[m_meshid].m_partitioner.map();
+            }
+            when mapinserted[m_meshid]( std::size_t error ) serial {
+              if (error) {
+                CkAbort("\n>>> ERROR: A Mapper chare was not assigned any mesh "
+                  "elements. This can happen in SMP-mode with a large +ppn "
+                  "parameter (number of worker threads per logical node) and is "
+                  "most likely the fault of the mesh partitioning algorithm not "
+                  "tolerating the case when it is asked to divide the "
+                  "computational domain into a number of partitions different "
+                  "than the number of ranks it is called on, i.e., in case of "
+                  "overdecomposition and/or calling the partitioner in SMP mode "
+                  "with +ppn larger than 1. Solution 1: Try a different "
+                  "partitioning algorithm (e.g., rcb instead of mj). Solution 2: "
+                  "Decrease +ppn.\n");
+              } else {
+                 meshes[m_meshid].m_mapper.doneInserting();
+                 meshes[m_meshid].m_mapper.setup( meshes[m_meshid].m_npoin,
+                                                  meshes[m_meshid].m_firstchunk );
+              }
+            }
+            when queried[m_meshid]() serial {
+              meshes[m_meshid].m_mapper.response();
+            }
+            when responded[m_meshid]() serial {
+              meshes[m_meshid].m_mapper.create();
+            }
+            when workinserted[m_meshid]() serial {
+              meshes[m_meshid].m_worker.doneInserting();
+            }
+            when workcreated[m_meshid]() serial {
+              std::cout << "Number of tetrahedra for mesh " << m_meshid << ": "
+                  << meshes[m_meshid].m_nelem << '\n';;
+              std::cout << "Number of points for mesh " << m_meshid << ": "
+                  << meshes[m_meshid].m_npoin << '\n';
+            }
+          }
+        }
+
+        // Both meshes are fully loaded on worker chares, so now we can test
+        // for collisions.
+        serial {
+          m_sourcemeshid = 0;
+          m_destmeshid = 1;
+          meshes[m_sourcemeshid].m_worker.collideTets();
+          meshes[m_destmeshid].m_worker.collideVertices();
+          CkStartQD(CkCallback(CkIndex_Transporter::solutionFound(), thisProxy));
+        }
+        // Collision detection library found collisions, now distribute them to
+        // the workers for further checking and solution transfer.
+        when processCollisions(int nColls, Collision colls[nColls]) serial {
+          distributeCollisions(nColls, colls);
+        }
+
+        // Solution has been transferred from source to destination, write out
+        // meshes and exit.
+        when solutionFound() {
+          forall [m_meshid] (0:1,1) {
+            serial { meshes[m_meshid].m_worker.out(); }
+            when written[m_meshid]() {}
+          }
+        }
+        serial { CkPrintf("done\n"); CkExit(); }
+      };
     }
 
   } // exam2m::

--- a/src/Transfer/Worker.cpp
+++ b/src/Transfer/Worker.cpp
@@ -21,7 +21,6 @@ extern CollideHandle collideHandle;
 using exam2m::Worker;
 
 Worker::Worker(
-  std::size_t meshid,
   std::size_t firstchunk,
   const tk::CProxy_MeshWriter& meshwriter,
   const tk::WorkerCallback& cbw,
@@ -32,7 +31,6 @@ Worker::Worker(
   const std::vector< std::size_t >& triinpoel,
   const std::map< int, std::vector< std::size_t > >& bnode,
   int nc ) :
-  m_meshid( meshid ),
   m_firstchunk( firstchunk ),
   m_cbw( cbw ),
   m_nchare( nc ),
@@ -89,8 +87,7 @@ Worker::Worker(
 
   // Tell the RTS that the Worker chares have been created and compute
   // the total number of mesh points across whole problem
-  contribute( sizeof( std::size_t ), &meshid, CkReduction::nop,
-      m_cbw.get< tag::workcreated >() );
+  contribute( m_cbw.get< tag::workcreated >() );
 }
 
 void

--- a/src/Transfer/Worker.hpp
+++ b/src/Transfer/Worker.hpp
@@ -26,7 +26,6 @@ class Worker : public CBase_Worker {
     //! Constructor
     explicit
       Worker(
-        std::size_t meshid,
         std::size_t firstchunk,
         const tk::CProxy_MeshWriter& meshwriter,
         const tk::WorkerCallback& cbw,
@@ -96,7 +95,6 @@ class Worker : public CBase_Worker {
     //! \brief Pack/Unpack serialize member function
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
     void pup( PUP::er &p ) override {
-      p | m_meshid;
       p | m_firstchunk;
       p | m_cbw;
       p | m_nchare;
@@ -127,9 +125,6 @@ class Worker : public CBase_Worker {
     //@}
 
   private:
-    //! Mesh ID
-    std::size_t m_meshid;
-    //! Mesh ID
     std::size_t m_firstchunk;
     //! Charm++ callbacks associated to compile-time tags for Worker
     tk::WorkerCallback m_cbw;

--- a/src/Transfer/worker.ci
+++ b/src/Transfer/worker.ci
@@ -21,8 +21,7 @@ module worker {
   namespace exam2m {
 
     array [1D] Worker {
-      entry Worker( std::size_t meshid,
-                    std::size_t firstchunk,
+      entry Worker( std::size_t firstchunk,
                     const tk::CProxy_MeshWriter& meshwriter,
                     const tk::WorkerCallback& cbw,
                     const std::vector< std::size_t >& ginpoel,


### PR DESCRIPTION
This changes all of the transporter control flow to SDAG, while also moving the mesh writing to the end of the run so that it occurs after the solution has been transferred.