### PR TITLE
Add capability to handle >2 meshes

### DIFF
--- a/src/Main/Driver.hpp
+++ b/src/Main/Driver.hpp
@@ -53,7 +53,6 @@ class Driver : public CBase_Driver {
     void pup( PUP::er& p ) override {
       p | m_meshes;
       p | m_sourcemeshid;
-      p | m_destmeshid;
       p | m_timer;
       p | m_curriter;
     }
@@ -96,8 +95,6 @@ class Driver : public CBase_Driver {
     std::vector<MeshData> m_meshes;
     //! ID of the source mesh
     int m_sourcemeshid;
-    //! ID of the dest mesh
-    int m_destmeshid;
     //! Timers
     std::vector< tk::Timer > m_timer;
     //! SDAG variable for iteration

--- a/src/Main/ExaM2M.cpp
+++ b/src/Main/ExaM2M.cpp
@@ -72,25 +72,22 @@ class Main : public CBase_Main {
       for (int i = 1; i < msg->argc; i++) CkPrintf("%s ", msg->argv[i]);
       CkPrintf("\n");
 
-      if ( msg->argc < 3 ) {
-        Throw( "The first two arguments must be exodus filenames");
+      if (msg->argc < 5) {
+        Throw( "Args require an iteration, virtualization, and at least two meshes" );
       }
 
-      if (msg->argc > 3) {
-        exam2m::g_totaliter = std::atoi( msg->argv[3] );
-      }
-
-      if (msg->argc > 4) {
-        exam2m::g_virtualization = std::atof( msg->argv[4] );
-      }
+      exam2m::g_totaliter = std::atoi( msg->argv[1] );
+      exam2m::g_virtualization = std::atof( msg->argv[2] );
 
       mainProxy = thisProxy;
 
       // Create the driver, add the two meshes, and tell it to run
       CProxy_Driver driverProxy = CProxy_Driver::ckNew( 0 );
-      driverProxy.addMesh(msg->argv[1]);
-      driverProxy.addMesh(msg->argv[2]);
-      driverProxy.run();
+
+      for (int i = 3; i < msg->argc; i++) {
+        driverProxy.addMesh(msg->argv[i]);
+      }
+      driverProxy.run(msg->argc - 3);
 
       delete msg;
     } catch (...) { tk::processExceptionCharm(); }

--- a/src/Main/driver.ci
+++ b/src/Main/driver.ci
@@ -31,8 +31,8 @@ module driver {
       entry [reductiontarget] void solutionfound();
       entry void meshAdded();
 
-      entry void run() {
-        forall [meshid] (0:1,1) {
+      entry void run(int num_meshes) {
+        forall [meshid] (0:num_meshes - 1,1) {
           when addMesh( const std::string& meshfile ) {
             // Create initial MeshData struct, and begin mesh loading
             serial { initMeshData( meshfile ); }
@@ -87,43 +87,45 @@ module driver {
           CkPrintf("ExaM2M> Prepared all meshes, "
                    "starting mesh-to-mesh transfer\n");
           m_sourcemeshid = 0;
-          m_destmeshid = 1;
-          exam2m::addMesh(
-              m_meshes[m_sourcemeshid].m_mesharray,
-              m_meshes[m_sourcemeshid].m_nchare,
-              CkCallback(CkIndex_Driver::meshAdded(), thisProxy));
-          exam2m::addMesh(
-              m_meshes[m_destmeshid].m_mesharray,
-              m_meshes[m_destmeshid].m_nchare,
-              CkCallback(CkIndex_Driver::meshAdded(), thisProxy));
+          for (int i = 0; i < num_meshes; i++) {
+            exam2m::addMesh(
+                m_meshes[i].m_mesharray,
+                m_meshes[i].m_nchare,
+                CkCallback(CkIndex_Driver::meshAdded(), thisProxy));
+          }
         }
 
-        when meshAdded(), meshAdded() {
-          serial {
-            CkPrintf("Meshes added to ExaM2M library, beginning transfers\n");
-            m_timer.emplace_back();
-          }
+        forall [meshid] (0:num_meshes - 1, 1) when meshAdded() {}
 
-          for (m_curriter = 0; m_curriter < g_totaliter; m_curriter++) {
-            // Begin mesh to mesh transfer
-            serial {
-              m_timer[0].zero();
-              m_meshes[m_sourcemeshid].m_mesharray.transferSource();
-              m_meshes[m_destmeshid].m_mesharray.transferDest();
-            }
-            // Solution has been transferred from source to destination, write out
-            // meshes and exit.
-            when solutionfound() {
-              serial {
-                CkPrintf("ExaM2M> Library iteration %i completed in: %f sec\n",
-                    m_curriter, m_timer[0].dsec());
+        serial {
+          CkPrintf("Meshes added to ExaM2M library, beginning transfers\n");
+          m_timer.emplace_back();
+        }
+
+        for (m_curriter = 0; m_curriter < g_totaliter; m_curriter++) {
+          // Begin mesh to mesh transfer
+          serial {
+            m_timer[0].zero();
+            for (int i = 0; i < num_meshes; i++) {
+              if (i == m_sourcemeshid) {
+                m_meshes[i].m_mesharray.transferSource();
+              } else {
+                m_meshes[i].m_mesharray.transferDest();
               }
+            }
+          }
+          // Solution has been transferred from source to destination, write out
+          // meshes and exit.
+          when solutionfound() {
+            serial {
+              CkPrintf("ExaM2M> Library iteration %i completed in: %f sec\n",
+                  m_curriter, m_timer[0].dsec());
             }
           }
         }
 
         // Write out final mesh data
-        forall [meshid] (0:1,1) {
+        forall [meshid] (0:num_meshes - 1,1) {
           serial { m_meshes[meshid].m_mesharray.out(meshid); }
           when written[meshid]() {}
         }

--- a/src/NoWarning/controller.decl.h
+++ b/src/NoWarning/controller.decl.h
@@ -50,6 +50,7 @@
   #pragma GCC diagnostic ignored "-Wfloat-equal"
   #pragma GCC diagnostic ignored "-Wextra"
   #pragma GCC diagnostic ignored "-Wdeprecated-copy"
+  #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #elif defined(__INTEL_COMPILER)
   #pragma warning( push )
   #pragma warning( disable: 181 )

--- a/src/Transfer/Controller.cpp
+++ b/src/Transfer/Controller.cpp
@@ -81,17 +81,98 @@ void Controller::setMesh( CkArrayID p, MeshData d ) {
 }
 
 void Controller::setDestPoints(CkArrayID p, int index, tk::UnsMesh::Coords* coords, const tk::Fields& u, CkCallback cb) {
-  m_destmesh = static_cast<std::size_t>(CkGroupID(p).idx);
-  Worker* w = proxyMap[m_destmesh].m_proxy[index].ckLocal();
+  proxyMap[CkGroupID(p).idx].dest = true;
+  Worker* w = proxyMap[CkGroupID(p).idx].m_proxy[index].ckLocal();
   assert(w);
   w->setDestPoints(coords, u, cb);
 }
 
 void Controller::setSourceTets(CkArrayID p, int index, std::vector< std::size_t >* inpoel, tk::UnsMesh::Coords* coords, const tk::Fields& u) {
-  m_sourcemesh = static_cast<std::size_t>(CkGroupID(p).idx);
-  Worker* w = proxyMap[m_sourcemesh].m_proxy[index].ckLocal();
+  proxyMap[CkGroupID(p).idx].dest = false;
+  Worker* w = proxyMap[CkGroupID(p).idx].m_proxy[index].ckLocal();
   assert(w);
   w->setSourceTets(inpoel, coords, u);
+}
+
+void
+Controller::separateCollisions(
+    std::unordered_map<MeshData, std::vector<DetailedCollision>*>& outgoing,
+    bool dest, int nColl, Collision* colls) {
+  for (const auto& itr : proxyMap) {
+    if (itr.second.dest == dest) {
+      outgoing[itr.second] = new std::vector<DetailedCollision>[itr.second.m_nchare];
+    }
+  }
+
+  // Separate collisions based on the mesh chare they belong to
+  for (int i = 0; i < nColl; i++) {
+    bool found = false;
+    for (auto& itr : outgoing) {
+      const auto& mesh = itr.first;
+      DetailedCollision coll;
+      const int aidx = colls[i].A.chunk - mesh.m_firstchunk;
+      const int bidx = colls[i].B.chunk - mesh.m_firstchunk;
+      if (aidx >= 0 && aidx < mesh.m_nchare) {
+        if (found) CkAbort("Multiple meshes of the same type in collision\n");
+        if (dest) {
+          coll.dest_chunk = colls[i].A.chunk;
+          coll.dest_index = colls[i].A.number;
+          coll.source_chunk = colls[i].B.chunk;
+          coll.source_index = colls[i].B.number;
+        } else {
+          coll.dest_chunk = colls[i].B.chunk;
+          coll.dest_index = colls[i].B.number;
+          coll.source_chunk = colls[i].A.chunk;
+          coll.source_index = colls[i].A.number;
+        }
+        itr.second[aidx].push_back(coll);
+        found = true;
+      }
+
+      if (bidx >= 0 && bidx < mesh.m_nchare) {
+        if (found) CkAbort("Multiple meshes of the same type in collision\n");
+        if (dest) {
+          coll.dest_chunk = colls[i].B.chunk;
+          coll.dest_index = colls[i].B.number;
+          coll.source_chunk = colls[i].A.chunk;
+          coll.source_index = colls[i].A.number;
+        } else {
+          coll.dest_chunk = colls[i].A.chunk;
+          coll.dest_index = colls[i].A.number;
+          coll.source_chunk = colls[i].B.chunk;
+          coll.source_index = colls[i].B.number;
+        }
+        itr.second[bidx].push_back(coll);
+        found = true;
+      }
+    }
+    if (!found) CkAbort("Invalid collision in list\n");
+  }
+}
+
+void
+Controller::separateCollisions(
+    std::unordered_map<MeshData, std::vector<DetailedCollision>*>& outgoing,
+    bool dest, int nColl, DetailedCollision* colls) {
+  for (const auto& itr : proxyMap) {
+    if (itr.second.dest == dest) {
+      // TODO: This should be made a vector probably to avoid memory management
+      outgoing[itr.second] = new std::vector<DetailedCollision>[itr.second.m_nchare];
+    }
+  }
+
+  // Separate collisions based on the destination mesh chare they belong to
+  for (int i = 0; i < nColl; i++) {
+    for (auto& itr : outgoing) {
+      const auto& mesh = itr.first;
+      int chunk;
+      if (dest) chunk = colls[i].dest_chunk - mesh.m_firstchunk;
+      else chunk = colls[i].source_chunk - mesh.m_firstchunk;
+      if (chunk >= 0 && chunk < mesh.m_nchare) {
+        itr.second[chunk].push_back(colls[i]);
+      }
+    }
+  }
 }
 
 void
@@ -105,28 +186,20 @@ Controller::distributeCollisions(int nColl, Collision* colls)
 // *****************************************************************************
 {
   CkPrintf("Collisions found: %i\n", nColl);
-  auto first = static_cast<int>(proxyMap[m_destmesh].m_firstchunk);
-  auto nchare = static_cast<int>(proxyMap[m_destmesh].m_nchare);
-  std::vector<Collision> separated[nchare];
 
-  // Separate collisions based on the destination mesh chare they belong to
-  for (int i = 0; i < nColl; i++) {
-    if (colls[i].A.chunk >= first && colls[i].A.chunk < first + nchare) {
-      separated[static_cast<std::size_t>(colls[i].A.chunk - first)].push_back(colls[i]);
-    } else {
-      separated[static_cast<std::size_t>(colls[i].B.chunk - first)].push_back(colls[i]);
-    }
-  }
+  std::unordered_map<MeshData, std::vector<DetailedCollision>*> outgoing;
+  separateCollisions(outgoing, true, nColl, colls);
 
   // Send out each list to the destination chares for further processing
-  for (int i = 0; i < nchare; i++) {
-    CkPrintf("Dest mesh chunk %i has %lu\n", i, separated[i].size());
-    proxyMap[m_destmesh].m_proxy[i].processCollisions(
-        proxyMap[m_sourcemesh].m_proxy,
-        proxyMap[m_sourcemesh].m_nchare,
-        proxyMap[m_sourcemesh].m_firstchunk,
-        static_cast<int>(separated[i].size()),
-        separated[i].data() );
+  for (auto& itr : outgoing) {
+    auto& mesh = itr.first;
+    // TODO: Don't send out empty messages
+    for (int i = 0; i < mesh.m_nchare; i++) {
+      mesh.m_proxy[i].processCollisions(
+          static_cast<int>(itr.second[i].size()),
+          itr.second[i].data() );
+    }
+    delete[] itr.second;
   }
 }
 

--- a/src/Transfer/Controller.hpp
+++ b/src/Transfer/Controller.hpp
@@ -21,18 +21,51 @@ class MeshData {
     CProxy_Worker m_proxy;
     int m_firstchunk;
     int m_nchare;
+    bool dest;
     void pup(PUP::er& p) {
       p | m_proxy;
       p | m_firstchunk;
       p | m_nchare;
+      p | dest;
     }
 };
+
+class DetailedCollision {
+public:
+  std::size_t source_chunk, dest_chunk;
+  std::size_t source_index, dest_index;
+  // TODO: Can this just be a more generic type like std::array
+  CkVector3d point;
+  void pup(PUP::er& p) {
+    p | source_chunk; p | source_index;
+    p | dest_chunk; p | dest_index;
+    p | point;
+  }
+};
+}
+
+namespace std {
+  template <>
+  struct hash<exam2m::MeshData> {
+    size_t operator()(const exam2m::MeshData& m) const {
+      return hash<int>()(m.m_firstchunk);
+    }
+  };
+
+  template<>
+  struct equal_to<exam2m::MeshData> {
+    bool operator()(const exam2m::MeshData& m1, const exam2m::MeshData& m2) const {
+      return equal_to<int>()(m1.m_firstchunk, m2.m_firstchunk);
+    }
+  };
+}
+
+namespace exam2m {
 
 class Controller : public CBase_Controller {
   private:
     std::unordered_map<CmiUInt8, MeshData> proxyMap;
     int current_chunk;
-    CmiUInt8 m_sourcemesh, m_destmesh;
 
   public:
     Controller();
@@ -51,6 +84,13 @@ class Controller : public CBase_Controller {
     void setDestPoints(CkArrayID p, int index, tk::UnsMesh::Coords* coords,
                        const tk::Fields& u, CkCallback cb);
     void distributeCollisions(int nColl, Collision* colls);
+    void separateCollisions(
+        std::unordered_map<MeshData, std::vector<DetailedCollision>*>& outgoing,
+        bool dest, int nColl, Collision* colls);
+    void separateCollisions(
+        std::unordered_map<MeshData, std::vector<DetailedCollision>*>& outgoing,
+        bool dest, int nColl, DetailedCollision* colls);
+
 };
 
 }

--- a/src/Transfer/Controller.hpp
+++ b/src/Transfer/Controller.hpp
@@ -77,6 +77,9 @@ class Controller : public CBase_Controller {
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif
+
+    using MeshDict = std::unordered_map<MeshData, std::vector<std::vector<DetailedCollision>>>;
+
     void addMesh(CkArrayID p, int elem, CkCallback cb);
     void setMesh(CkArrayID p, MeshData d);
     void setSourceTets(CkArrayID p, int index, std::vector< std::size_t >* inpoel,
@@ -84,12 +87,10 @@ class Controller : public CBase_Controller {
     void setDestPoints(CkArrayID p, int index, tk::UnsMesh::Coords* coords,
                        const tk::Fields& u, CkCallback cb);
     void distributeCollisions(int nColl, Collision* colls);
-    void separateCollisions(
-        std::unordered_map<MeshData, std::vector<DetailedCollision>*>& outgoing,
-        bool dest, int nColl, Collision* colls);
-    void separateCollisions(
-        std::unordered_map<MeshData, std::vector<DetailedCollision>*>& outgoing,
-        bool dest, int nColl, DetailedCollision* colls);
+    void separateCollisions(MeshDict& outgoing, bool dest, int nColl,
+                            Collision* colls) const;
+    void separateCollisions(MeshDict& outgoing, bool dest, int nColl,
+                            DetailedCollision* colls) const;
 
 };
 

--- a/src/Transfer/Worker.cpp
+++ b/src/Transfer/Worker.cpp
@@ -168,7 +168,6 @@ Worker::processCollisions(
 // *****************************************************************************
 {
   const tk::UnsMesh::Coords& coord = *m_coord;
-  int mychunk = thisIndex + m_firstchunk;
 
   Controller::MeshDict outgoing;
   // Separate collisions for source meshes (dest = false)

--- a/src/Transfer/Worker.cpp
+++ b/src/Transfer/Worker.cpp
@@ -170,7 +170,7 @@ Worker::processCollisions(
   const tk::UnsMesh::Coords& coord = *m_coord;
   int mychunk = thisIndex + m_firstchunk;
 
-  std::unordered_map<MeshData, std::vector<DetailedCollision>*> outgoing;
+  Controller::MeshDict outgoing;
   // Separate collisions for source meshes (dest = false)
   controllerProxy.ckLocalBranch()->separateCollisions(outgoing, false, nColl, colls);
 
@@ -195,7 +195,6 @@ Worker::processCollisions(
       itr.first.m_proxy[i].determineActualCollisions(
           thisProxy, thisIndex, itr.second[i].size(), itr.second[i].data());
     }
-    delete[] itr.second;
   }
 }
 

--- a/src/Transfer/Worker.hpp
+++ b/src/Transfer/Worker.hpp
@@ -15,7 +15,6 @@
 #include "UnsMesh.hpp"
 #include "CommMap.hpp"
 #include "Fields.hpp"
-#include "ckvector3d.h"
 
 #include "NoWarning/worker.decl.h"
 

--- a/src/Transfer/Worker.hpp
+++ b/src/Transfer/Worker.hpp
@@ -15,17 +15,11 @@
 #include "UnsMesh.hpp"
 #include "CommMap.hpp"
 #include "Fields.hpp"
+#include "ckvector3d.h"
 
 #include "NoWarning/worker.decl.h"
 
 namespace exam2m {
-
-class PotentialCollision {
-  public:
-    std::size_t source_index, dest_index;
-    CkVector3d point;
-    void pup(PUP::er& p) { p | source_index; p | dest_index; p | point; }
-};
 
 class SolutionData {
   public:
@@ -63,17 +57,14 @@ class Worker : public CBase_Worker {
                         CkCallback cb );
 
     //! Process potential collisions in the destination mesh
-    void processCollisions( CProxy_Worker proxy,
-                            int nchare,
-                            int offset,
-                            int nColls,
-                            Collision* colls );
+    void processCollisions( int nColls,
+                            DetailedCollision* colls );
 
     //! Identify actual collisions in the source mesh
     void determineActualCollisions( CProxy_Worker proxy,
                                     int index,
                                     int nColls,
-                                    PotentialCollision* colls ) const;
+                                    DetailedCollision* colls ) const;
 
     //! Transfer the interpolated solution data back to destination mesh
     void transferSolution( std::size_t nPoints, SolutionData* soln );
@@ -120,7 +111,7 @@ class Worker : public CBase_Worker {
     //! Determine if a point is in a tet
     bool intet(const CkVector3d &point,
                std::size_t e,
-               std::array< real, 4 >& N) const;
+               std::array< tk::real, 4 >& N) const;
 };
 
 } // exam2m::

--- a/src/Transfer/controller.ci
+++ b/src/Transfer/controller.ci
@@ -7,8 +7,6 @@ module controller {
     readonly CProxy_Controller controllerProxy;
     readonly CollideHandle collideHandle;
 
-    class MeshData;
-
     mainchare LibMain {
       entry LibMain(CkArgMsg* msg);
     };

--- a/src/Transfer/controller.ci
+++ b/src/Transfer/controller.ci
@@ -1,5 +1,7 @@
 module controller {
 
+  include "ckvector3d.h";
+
   extern module worker;
 
   namespace exam2m {

--- a/src/Transfer/worker.ci
+++ b/src/Transfer/worker.ci
@@ -11,7 +11,6 @@
 module worker {
 
   extern module meshwriter;
-  extern module worker;
 
   include "UnsMesh.hpp";
   include "Callback.hpp";

--- a/src/Transfer/worker.ci
+++ b/src/Transfer/worker.ci
@@ -15,6 +15,8 @@ module worker {
   include "UnsMesh.hpp";
   include "Callback.hpp";
   include "CommMap.hpp";
+  // NOTE: Including this here avoids warnings
+  include "collidecharm.h";
 
   namespace exam2m {
 

--- a/src/Transfer/worker.ci
+++ b/src/Transfer/worker.ci
@@ -11,6 +11,7 @@
 module worker {
 
   extern module meshwriter;
+  extern module worker;
 
   include "UnsMesh.hpp";
   include "Callback.hpp";

--- a/src/Transfer/worker.ci
+++ b/src/Transfer/worker.ci
@@ -11,30 +11,25 @@
 module worker {
 
   extern module meshwriter;
-  extern module worker;
 
   include "UnsMesh.hpp";
   include "Callback.hpp";
   include "CommMap.hpp";
-  include "collidecharm.h";
 
   namespace exam2m {
 
-    class PotentialCollision;
+    class DetailedCollision;
     class SolutionData;
     class MeshData;
 
     array [1D] Worker {
       entry Worker( CkArrayID p, MeshData d, CkCallback cb );
-      entry void processCollisions( CProxy_Worker proxy,
-                                    int nchares,
-                                    int offset,
-                                    int nColls,
-                                    Collision colls[nColls] );
+      entry void processCollisions( int nColls,
+                                    DetailedCollision colls[nColls] );
       entry void determineActualCollisions( CProxy_Worker proxy,
                                             int index,
                                             int nColls,
-                                            PotentialCollision colls[nColls] );
+                                            DetailedCollision colls[nColls] );
       entry void transferSolution( std::size_t nPoints,
                                    SolutionData soln[nPoints] );
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ include(add_regression_test)
 add_regression_test(self_sphere ${EXAM2M_EXECUTABLE}
                     NUMPES 1
                     INPUTFILES meshes/sphere_tetra.0.2.exo
-                    ARGS sphere_tetra.0.2.exo sphere_tetra.0.2.exo 3
+                    ARGS 1 0.0 sphere_tetra.0.2.exo sphere_tetra.0.2.exo
                     BIN_BASELINE self_sphere.src.std.exo
                                  self_sphere.dst.std.exo
                     BIN_RESULT out.0.e-s.0.1.0
@@ -26,7 +26,7 @@ add_regression_test(self_sphere ${EXAM2M_EXECUTABLE}
 add_regression_test(sphere2box ${EXAM2M_EXECUTABLE}
                     NUMPES 1
                     INPUTFILES meshes/sphere_full.exo meshes/unitcube_94K.exo
-                    ARGS sphere_full.exo unitcube_94K.exo 3
+                    ARGS 3 0.0 sphere_full.exo unitcube_94K.exo
                     BIN_BASELINE sphere2box.src.std.exo
                                  sphere2box.dst.std.exo
                     BIN_RESULT out.0.e-s.0.1.0
@@ -37,7 +37,7 @@ add_regression_test(sphere2box ${EXAM2M_EXECUTABLE}
                     NUMPES 2
                     PPN 1
                     INPUTFILES meshes/sphere_full.exo meshes/unitcube_94K.exo
-                    ARGS sphere_full.exo unitcube_94K.exo 3
+                    ARGS 3 0.0 sphere_full.exo unitcube_94K.exo
                     BIN_BASELINE sphere2box_pe2.src.std.exo.0
                                  sphere2box_pe2.src.std.exo.1
                                  sphere2box_pe2.dst.std.exo.0
@@ -52,7 +52,7 @@ add_regression_test(sphere2box_u0.8 ${EXAM2M_EXECUTABLE}
                     NUMPES 2
                     PPN 1
                     INPUTFILES meshes/sphere_full.exo meshes/unitcube_94K.exo
-                    ARGS sphere_full.exo unitcube_94K.exo 1 0.8
+                    ARGS 1 0.8 sphere_full.exo unitcube_94K.exo
                     BIN_BASELINE sphere2box_u0.8_pe2.src.std.exo.0
                                  sphere2box_u0.8_pe2.src.std.exo.1
                                  sphere2box_u0.8_pe2.src.std.exo.2


### PR DESCRIPTION
These changes allow for combinations of multiple source and destination meshes. Destination meshes will only be tested for overlap with source meshes and vice-versa.