### PR TITLE
Update testing to exploit linear nature of interpolation

### DIFF
--- a/src/Main/Driver.cpp
+++ b/src/Main/Driver.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 
 #include "Driver.hpp"
+#include "MeshArray.hpp"
 #include "ExodusIIMeshReader.hpp"
 #include "LoadDistributor.hpp"
 

--- a/src/Main/Driver.hpp
+++ b/src/Main/Driver.hpp
@@ -52,7 +52,6 @@ class Driver : public CBase_Driver {
     //!    checkpoint/restart.
     void pup( PUP::er& p ) override {
       p | m_meshes;
-      p | m_sourcemeshid;
       p | m_timer;
       p | m_curriter;
     }
@@ -93,8 +92,6 @@ class Driver : public CBase_Driver {
 
     //! Mesh Data for all meshes
     std::vector<MeshData> m_meshes;
-    //! ID of the source mesh
-    int m_sourcemeshid;
     //! Timers
     std::vector< tk::Timer > m_timer;
     //! SDAG variable for iteration

--- a/src/Main/MeshArray.hpp
+++ b/src/Main/MeshArray.hpp
@@ -16,9 +16,66 @@
 #include "CommMap.hpp"
 #include "Fields.hpp"
 
+namespace exam2m {
+
+class Solution : public PUP::able {
+PUPable_abstract(Solution);
+public:
+  virtual tk::real f(tk::real x, tk::real y, tk::real z) const = 0;
+};
+
+}
+
 #include "NoWarning/mesharray.decl.h"
 
 namespace exam2m {
+
+/*class Solution : public PUP::able {
+PUPable_abstract(Solution);
+public:
+  virtual tk::real f(tk::real x, tk::real y, tk::real z) const = 0;
+};*/
+
+class EmptySolution : public Solution {
+PUPable_decl(EmptySolution);
+public:
+  EmptySolution() {}
+  EmptySolution(CkMigrateMessage* m) {}
+  tk::real f(tk::real x, tk::real y, tk::real z) const {
+    return -1.0;
+  }
+};
+
+class ExampleSolution : public Solution {
+PUPable_decl(ExampleSolution);
+public:
+  ExampleSolution() {}
+  ExampleSolution(CkMigrateMessage* m) {}
+  tk::real f(tk::real x, tk::real y, tk::real z) const {
+    return 1.0 * exp( -(x*x + y*y + z*z)/(2.0 * 0.05) );
+  }
+};
+
+class LinearSolution : public Solution {
+PUPable_decl(LinearSolution);
+private:
+  tk::real a, b, c, d;
+public:
+  LinearSolution(tk::real _a, tk::real _b, tk::real _c, tk::real _d)
+      : a(_a), b(_b), c(_c), d(_d) {}
+  LinearSolution(CkMigrateMessage* m) {}
+
+  tk::real f(tk::real x, tk::real y, tk::real z) const {
+    return a*x + b*y + c*z + d;
+  }
+
+  virtual void pup(PUP::er& p) {
+    p | a;
+    p | b;
+    p | c;
+    p | d;
+  }
+};
 
 //! MeshArray chare array holding part of a mesh
 class MeshArray : public CBase_MeshArray {
@@ -69,6 +126,8 @@ class MeshArray : public CBase_MeshArray {
     //! Mesh and field data written to file(s)
     void written();
 
+    void setSolution(Solution& s, CkCallback cb);
+    void checkSolution(Solution& s, CkCallback cb);
     void solutionFound();
     void transferSource();
     void transferDest();

--- a/src/Main/driver.ci
+++ b/src/Main/driver.ci
@@ -29,9 +29,13 @@ module driver {
       entry [reductiontarget] void workcreated();
       entry [reductiontarget] void written();
       entry [reductiontarget] void solutionfound();
-      entry void meshAdded();
+      entry [reductiontarget] void meshAdded();
+      entry [reductiontarget] void solutionSet();
+      entry [reductiontarget] void solutionChecked();
+      entry void setupDone();
+      entry void testDone();
 
-      entry void run(int num_meshes) {
+      entry void setup(int num_meshes) {
         forall [meshid] (0:num_meshes - 1,1) {
           when addMesh( const std::string& meshfile ) {
             // Create initial MeshData struct, and begin mesh loading
@@ -75,52 +79,60 @@ module driver {
               m_meshes[meshid].m_mesharray.doneInserting();
             }
             when workcreated[meshid]() serial {
-              CkPrintf("ExaM2M> Created worker for mesh %i\n", meshid);
+              CkPrintf("ExaM2M> Created MeshArraay for mesh %i\n", meshid);
+              CkCallback cb(CkReductionTarget(Driver, meshAdded), thisProxy);
+              cb.setRefnum(meshid);
+              exam2m::addMesh(
+                  m_meshes[meshid].m_mesharray,
+                  m_meshes[meshid].m_nchare,
+                  cb);
+            }
+            when meshAdded[meshid]() serial {
+              CkPrintf("ExaM2M> Linked Worker for mesh %i\n", meshid);
               std::cout << "ExaM2M> Mesh " << meshid << " nelem: "
                         << m_meshes[meshid].m_nelem << ", npoin: "
                         << m_meshes[meshid].m_npoin << '\n';
             }
           }
         }
+        serial { thisProxy.setupDone(); }
+      }
 
+      entry void doIteration(int num_meshes, int source) {
         serial {
-          CkPrintf("ExaM2M> Prepared all meshes, "
-                   "starting mesh-to-mesh transfer\n");
-          m_sourcemeshid = 0;
           for (int i = 0; i < num_meshes; i++) {
-            exam2m::addMesh(
-                m_meshes[i].m_mesharray,
-                m_meshes[i].m_nchare,
-                CkCallback(CkIndex_Driver::meshAdded(), thisProxy));
+            if (i == source) {
+              m_meshes[i].m_mesharray.transferSource();
+            } else {
+              m_meshes[i].m_mesharray.transferDest();
+            }
           }
         }
+      }
 
-        forall [meshid] (0:num_meshes - 1, 1) when meshAdded() {}
-
+      entry void testVsFile(int num_meshes, int source) {
         serial {
-          CkPrintf("Meshes added to ExaM2M library, beginning transfers\n");
-          m_timer.emplace_back();
+          ExampleSolution s1;
+          EmptySolution s2;
+          for (int i = 0; i < num_meshes; i++) {
+            if (i == source)
+              m_meshes[i].m_mesharray.setSolution(s1, CkCallback(CkReductionTarget(Driver, solutionSet),thisProxy));
+            else
+              m_meshes[i].m_mesharray.setSolution(s2, CkCallback(CkReductionTarget(Driver, solutionSet),thisProxy));
+          }
         }
-
+        forall [meshid] (0:num_meshes - 1,1) when solutionSet() {}
         for (m_curriter = 0; m_curriter < g_totaliter; m_curriter++) {
           // Begin mesh to mesh transfer
           serial {
-            m_timer[0].zero();
-            for (int i = 0; i < num_meshes; i++) {
-              if (i == m_sourcemeshid) {
-                m_meshes[i].m_mesharray.transferSource();
-              } else {
-                m_meshes[i].m_mesharray.transferDest();
-              }
-            }
+            m_timer[1].zero();
+            thisProxy.doIteration(num_meshes, 0);
           }
+
           // Solution has been transferred from source to destination, write out
           // meshes and exit.
-          when solutionfound() {
-            serial {
-              CkPrintf("ExaM2M> Library iteration %i completed in: %f sec\n",
-                  m_curriter, m_timer[0].dsec());
-            }
+          when solutionfound() serial {
+            CkPrintf("ExaM2M> Iteration %i completed in: %f sec\n", m_curriter, m_timer[1].dsec());
           }
         }
 
@@ -129,7 +141,70 @@ module driver {
           serial { m_meshes[meshid].m_mesharray.out(meshid); }
           when written[meshid]() {}
         }
-        serial { mainProxy.finalize(); }
+        serial { thisProxy.testDone(); }
+      }
+
+      entry void testLinear(int num_meshes) {
+        serial {
+          LinearSolution s(5,7,8,2);
+          for (int i = 0; i < num_meshes; i++) {
+            m_meshes[i].m_mesharray.setSolution(s, CkCallback(CkReductionTarget(Driver, solutionSet),thisProxy));
+          }
+        }
+        forall [meshid] (0:num_meshes - 1,1) when solutionSet() {}
+        serial {
+          m_timer[1].zero();
+          thisProxy.doIteration(num_meshes, 0);
+        }
+        when solutionfound() serial {
+          CkPrintf("ExaM2M> Initial transfer to dest completed in: %f sec\n", m_timer[1].dsec());
+          LinearSolution s(5,7,8,2);
+          for (int i = 0; i < num_meshes; i++) {
+            m_meshes[i].m_mesharray.checkSolution(s, CkCallback(CkReductionTarget(Driver, solutionChecked),thisProxy));
+          }
+        }
+        forall [meshid] (0:num_meshes - 1,1) when solutionChecked() {}
+        serial {
+          m_timer[1].zero();
+          thisProxy.doIteration(num_meshes, 1);
+        }
+        when solutionfound() serial {
+          CkPrintf("ExaM2M> Transfer back to source completed in: %f sec\n", m_timer[1].dsec());
+          m_timer[1].zero();
+          LinearSolution s(5,7,8,2);
+          for (int i = 0; i < num_meshes; i++) {
+            m_meshes[i].m_mesharray.checkSolution(s, CkCallback(CkReductionTarget(Driver, solutionChecked),thisProxy));
+          }
+        }
+        forall [meshid] (0:num_meshes - 1,1) when solutionChecked() {}
+        serial {
+          thisProxy.testDone();
+        }
+      }
+
+      entry void run(int num_meshes) {
+        serial {
+          m_timer.emplace_back();
+          m_timer[0].zero();
+          thisProxy.setup(num_meshes);
+        }
+        when setupDone() serial {
+          CkPrintf("ExaM2M> Meshes loaded in: %f sec\n", m_timer[0].dsec());
+
+          m_timer.emplace_back();
+
+          m_timer[0].zero();
+          thisProxy.testVsFile(num_meshes, 0);
+        }
+        when testDone() serial {
+          CkPrintf("ExaM2M> Empirical testing finished in: %f sec\n", m_timer[0].dsec());
+          m_timer[0].zero();
+          thisProxy.testLinear(num_meshes);
+        }
+        when testDone() serial {
+          CkPrintf("ExaM2M> Linear testing finished in: %f sec\n", m_timer[0].dsec());
+          mainProxy.finalize();
+        }
       };
     }
 

--- a/src/Main/mesharray.ci
+++ b/src/Main/mesharray.ci
@@ -18,6 +18,11 @@ module mesharray {
 
   namespace exam2m {
 
+    class Solution;
+    PUPable EmptySolution;
+    PUPable ExampleSolution;
+    PUPable LinearSolution;
+
     array [1D] MeshArray {
       entry MeshArray( const tk::CProxy_MeshWriter& meshwriter,
                        const tk::MeshCallback& cbw,
@@ -31,6 +36,8 @@ module mesharray {
       entry void out( int meshid );
       entry void written();
 
+      entry void setSolution(CkReference<exam2m::Solution>, CkCallback);
+      entry void checkSolution(CkReference<exam2m::Solution>, CkCallback);
       entry void solutionFound();
       entry void transferSource();
       entry void transferDest();

--- a/src/Transfer/Controller.cpp
+++ b/src/Transfer/Controller.cpp
@@ -55,7 +55,7 @@ LibMain::LibMain(CkArgMsg* msg) {
   controllerProxy = CProxy_Controller::ckNew();
 
   // TODO: Need to make sure this is actually correct
-  CollideGrid3d gridMap(CkVector3d(0, 0, 0),CkVector3d(2, 100, 2));
+  CollideGrid3d gridMap(CkVector3d(0, 0, 0),CkVector3d(0.5, 0.5, 0.5));
   collideHandle = CollideCreate(gridMap,
       CollideDistributedClient(CkCallback(exam2m::CkIndex_Controller::distributeCollisions(NULL),controllerProxy)));
       //CollideSerialClient(collisionHandler, 0));
@@ -236,7 +236,6 @@ Controller::distributeCollisions(int nColl, Collision* colls)
   // Send out each list to the destination chares for further processing
   for (auto& itr : outgoing) {
     auto& mesh = itr.first;
-    // TODO: Don't send out empty messages
     for (int i = 0; i < mesh.m_nchare; i++) {
       if (itr.second[i].size()) {
         num_sent++;
@@ -246,6 +245,7 @@ Controller::distributeCollisions(int nColl, Collision* colls)
       }
     }
   }
+  // TODO: Count is not getting reset between iterations
   CkPrintf("[%i]: Sent %i\n", CkMyPe(), num_sent);
   contribute(sizeof(int), &num_sent, CkReduction::sum_int, CkCallback(CkReductionTarget(Controller,allSent), thisProxy));
 }

--- a/src/Transfer/Controller.hpp
+++ b/src/Transfer/Controller.hpp
@@ -1,3 +1,6 @@
+#ifndef Controller_h
+#define Controller_h
+
 // Controller for the library
 
 #include "NoWarning/controller.decl.h"
@@ -105,3 +108,5 @@ class Controller : public CBase_Controller {
 };
 
 }
+
+#endif // Controller_h

--- a/src/Transfer/Worker.cpp
+++ b/src/Transfer/Worker.cpp
@@ -88,25 +88,13 @@ Worker::setDestPoints(
   m_u = const_cast< tk::Fields* >( &u );
   m_donecb = cb;
 
-  // Initialize msg counters, callback, and background solution data
+  // Initialize msg counters and callback
   m_numsent = 1; // Set to one to account for the extra message expected from
                  // the controller when cd is done.
   m_numreceived = 0;
-  background();
 
   // Send vertex data to the collision detection library
   collideVertices();
-}
-
-void
-Worker::background()
-// *****************************************************************************
-// Initialize dest mesh solution with background data
-//! \details This is useful to see what points did not receive solution.
-// *****************************************************************************
-{
-  tk::Fields& u = *m_u;
-  for (std::size_t i = 0; i < u.nunk(); ++i) u(i,0,0) = -1.0;
 }
 
 void

--- a/src/Transfer/Worker.hpp
+++ b/src/Transfer/Worker.hpp
@@ -100,9 +100,6 @@ class Worker : public CBase_Worker {
     //! Called once the transfer is complete (m_numsent == m_numreceived)
     CkCallback m_donecb;
 
-    //! Initialize dest mesh solution with background data
-    void background();
-
     //! Contribute vertex information to the collsion detection library
     void collideVertices();
 


### PR DESCRIPTION
Because the interpolation used is linear, if we use a linear solution for the data to be transferred, we can mathematically check correctness once the transfer completes. We can also transfer back from the destination to source and expect to get the same solution.