### PR TITLE
Update ExaM2M to use the distributed client from CD

### DIFF
--- a/src/Transfer/Controller.cpp
+++ b/src/Transfer/Controller.cpp
@@ -57,7 +57,8 @@ LibMain::LibMain(CkArgMsg* msg) {
   // TODO: Need to make sure this is actually correct
   CollideGrid3d gridMap(CkVector3d(0, 0, 0),CkVector3d(2, 100, 2));
   collideHandle = CollideCreate(gridMap,
-      CollideSerialClient(collisionHandler, 0));
+      CollideDistributedClient(CkCallback(exam2m::CkIndex_Controller::distributeCollisions(NULL),controllerProxy)));
+      //CollideSerialClient(collisionHandler, 0));
 }
 
 Controller::Controller() : current_chunk(0) {}
@@ -227,7 +228,7 @@ Controller::distributeCollisions(int nColl, Collision* colls)
 //! \param[in] colls The list of potential collisions
 // *****************************************************************************
 {
-  CkPrintf("Collisions found: %i\n", nColl);
+  CkPrintf("[%i]: Collisions found: %i\n", CkMyPe(), nColl);
 
   MeshDict outgoing;
   separateCollisions(outgoing, true, nColl, colls);

--- a/src/Transfer/Controller.cpp
+++ b/src/Transfer/Controller.cpp
@@ -61,7 +61,7 @@ LibMain::LibMain(CkArgMsg* msg) {
       //CollideSerialClient(collisionHandler, 0));
 }
 
-Controller::Controller() : current_chunk(0) {}
+Controller::Controller() : current_chunk(0), num_sent(0), num_received(0), total_sent(0) {}
 
 void
 Controller::addMesh(CkArrayID p, int elem, CkCallback cb)
@@ -238,11 +238,53 @@ Controller::distributeCollisions(int nColl, Collision* colls)
     auto& mesh = itr.first;
     // TODO: Don't send out empty messages
     for (int i = 0; i < mesh.m_nchare; i++) {
-      mesh.m_proxy[i].processCollisions(
-          static_cast<int>(itr.second[i].size()),
-          itr.second[i].data() );
+      if (itr.second[i].size()) {
+        num_sent++;
+        mesh.m_proxy[i].processCollisions(
+            static_cast<int>(itr.second[i].size()),
+            itr.second[i].data() );
+      }
     }
   }
+  CkPrintf("[%i]: Sent %i\n", CkMyPe(), num_sent);
+  contribute(sizeof(int), &num_sent, CkReduction::sum_int, CkCallback(CkReductionTarget(Controller,allSent), thisProxy));
+}
+
+void
+Controller::allSent(int total) {
+  if (CkMyPe() == 0) CkPrintf("Total Sent Across All PEs: %i\n", total);
+  total_sent = total;
+  checkReceived();
+}
+
+void
+Controller::collsReceived() {
+  num_received++;
+}
+
+void
+Controller::checkReceived() {
+  contribute(sizeof(int), &num_received, CkReduction::sum_int, CkCallback(CkReductionTarget(Controller,checkDone), thisProxy));
+}
+
+void
+Controller::checkDone(int total) {
+  total_received = total;
+  if (CkMyPe() == 0) CkPrintf("Total Received so far across All PEs: %i\n", total);
+  if (total_sent != total_received) {
+    checkReceived();
+  } else {
+    if (CkMyPe() == 0) {
+      for (auto m : proxyMap) {
+        if (m.second.dest) {
+          m.second.m_proxy.done();
+        }
+      }
+    }
+  }
+  // TODO: If we have received everything, it's possible some workers did not have any collisions?
+  // If so, we need to bcast or something to let them know they can contribute to the done reduction
+  // or use some other method of CD to check when the transfer is complete.
 }
 
 #if defined(__clang__)

--- a/src/Transfer/Controller.hpp
+++ b/src/Transfer/Controller.hpp
@@ -67,6 +67,8 @@ class Controller : public CBase_Controller {
     std::unordered_map<CmiUInt8, MeshData> proxyMap;
     int current_chunk;
 
+    int num_sent, num_received, total_sent, total_received;
+
   public:
     Controller();
     #if defined(__clang__)
@@ -96,6 +98,10 @@ class Controller : public CBase_Controller {
     void separateCollisions(MeshDict& outgoing, bool dest, int nColl,
                             DetailedCollision* colls) const;
 
+    void allSent(int);
+    void collsReceived();
+    void checkReceived();
+    void checkDone(int);
 };
 
 }

--- a/src/Transfer/Controller.hpp
+++ b/src/Transfer/Controller.hpp
@@ -86,6 +86,10 @@ class Controller : public CBase_Controller {
                        tk::UnsMesh::Coords* coords, const tk::Fields& u);
     void setDestPoints(CkArrayID p, int index, tk::UnsMesh::Coords* coords,
                        const tk::Fields& u, CkCallback cb);
+
+    void distributeCollisions(CkDataMsg* msg) {
+      distributeCollisions(msg->getSize()/sizeof(Collision), (Collision*)msg->getData());
+    }
     void distributeCollisions(int nColl, Collision* colls);
     void separateCollisions(MeshDict& outgoing, bool dest, int nColl,
                             Collision* colls) const;

--- a/src/Transfer/Worker.hpp
+++ b/src/Transfer/Worker.hpp
@@ -68,6 +68,8 @@ class Worker : public CBase_Worker {
     //! Transfer the interpolated solution data back to destination mesh
     void transferSolution( std::size_t nPoints, SolutionData* soln );
 
+    void done();
+
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{
     //! \brief Pack/Unpack serialize member function

--- a/src/Transfer/controller.ci
+++ b/src/Transfer/controller.ci
@@ -18,6 +18,9 @@ module controller {
 
       entry void addMesh(CkArrayID p, int elem, CkCallback cb);
       entry void distributeCollisions(CkDataMsg* m);
+
+      entry [reductiontarget] void allSent(int);
+      entry [reductiontarget] void checkDone(int);
     };
   }
 };

--- a/src/Transfer/controller.ci
+++ b/src/Transfer/controller.ci
@@ -17,6 +17,7 @@ module controller {
       entry Controller();
 
       entry void addMesh(CkArrayID p, int elem, CkCallback cb);
+      entry void distributeCollisions(CkDataMsg* m);
     };
   }
 };

--- a/src/Transfer/worker.ci
+++ b/src/Transfer/worker.ci
@@ -34,6 +34,8 @@ module worker {
                                             DetailedCollision colls[nColls] );
       entry void transferSolution( std::size_t nPoints,
                                    SolutionData soln[nPoints] );
+
+      entry void done();
     }
 
   } // exam2m::

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ include(add_regression_test)
 add_regression_test(self_sphere ${EXAM2M_EXECUTABLE}
                     NUMPES 1
                     INPUTFILES meshes/sphere_tetra.0.2.exo
-                    ARGS 1 0.0 sphere_tetra.0.2.exo sphere_tetra.0.2.exo
+                    ARGS 3 0.0 sphere_tetra.0.2.exo sphere_tetra.0.2.exo
                     BIN_BASELINE self_sphere.src.std.exo
                                  self_sphere.dst.std.exo
                     BIN_RESULT out.0.e-s.0.1.0
@@ -26,7 +26,7 @@ add_regression_test(self_sphere ${EXAM2M_EXECUTABLE}
 add_regression_test(sphere2box ${EXAM2M_EXECUTABLE}
                     NUMPES 1
                     INPUTFILES meshes/sphere_full.exo meshes/unitcube_94K.exo
-                    ARGS 1 0.0 sphere_full.exo unitcube_94K.exo
+                    ARGS 3 0.0 sphere_full.exo unitcube_94K.exo
                     BIN_BASELINE sphere2box.src.std.exo
                                  sphere2box.dst.std.exo
                     BIN_RESULT out.0.e-s.0.1.0
@@ -37,7 +37,7 @@ add_regression_test(sphere2box ${EXAM2M_EXECUTABLE}
                     NUMPES 2
                     PPN 1
                     INPUTFILES meshes/sphere_full.exo meshes/unitcube_94K.exo
-                    ARGS 1 0.0 sphere_full.exo unitcube_94K.exo
+                    ARGS 3 0.0 sphere_full.exo unitcube_94K.exo
                     BIN_BASELINE sphere2box_pe2.src.std.exo.0
                                  sphere2box_pe2.src.std.exo.1
                                  sphere2box_pe2.dst.std.exo.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ add_regression_test(self_sphere ${EXAM2M_EXECUTABLE}
 add_regression_test(sphere2box ${EXAM2M_EXECUTABLE}
                     NUMPES 1
                     INPUTFILES meshes/sphere_full.exo meshes/unitcube_94K.exo
-                    ARGS 3 0.0 sphere_full.exo unitcube_94K.exo
+                    ARGS 1 0.0 sphere_full.exo unitcube_94K.exo
                     BIN_BASELINE sphere2box.src.std.exo
                                  sphere2box.dst.std.exo
                     BIN_RESULT out.0.e-s.0.1.0
@@ -37,7 +37,7 @@ add_regression_test(sphere2box ${EXAM2M_EXECUTABLE}
                     NUMPES 2
                     PPN 1
                     INPUTFILES meshes/sphere_full.exo meshes/unitcube_94K.exo
-                    ARGS 3 0.0 sphere_full.exo unitcube_94K.exo
+                    ARGS 1 0.0 sphere_full.exo unitcube_94K.exo
                     BIN_BASELINE sphere2box_pe2.src.std.exo.0
                                  sphere2box_pe2.src.std.exo.1
                                  sphere2box_pe2.dst.std.exo.0


### PR DESCRIPTION
These changes make it so ExaM2M uses the distributed client in the collision detection library, to eliminate the bottleneck created by centralizing all potential collisions from the broad phase. It also adds a more precise completion detection mechanism which cuts down on the the number of messages used in the narrow phase.